### PR TITLE
Typo to Lloyds Register Foundation

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -41,7 +41,7 @@
 				<li>Chris Williams, University of Edinburgh
         	</ul>
         <h2>Sponsors</h2>
-        <p>We acknowledge generous contributions from our sponsors Alan Turing Institute, and Lloyds Registry Foundation.</p>
+        <p>We acknowledge generous contributions from our sponsors Alan Turing Institute, and Lloyds Register Foundation.</p>
         	<a href="https://www.turing.ac.uk/" >
         		<img class="logo" src="./images/ati.png" width="140px" height="65px"></a>
 			<a href="http://www.lrfoundation.org.uk/" >


### PR DESCRIPTION
Requested by James, misspelling on sponsor name.